### PR TITLE
Simd data leakage

### DIFF
--- a/PrySec.Core/Memory/IMemoryAccess.cs
+++ b/PrySec.Core/Memory/IMemoryAccess.cs
@@ -15,6 +15,12 @@ public unsafe interface IMemoryAccess<T> : IDisposable where T : unmanaged
     /// </summary>
     public int Count { get; }
 
+    public T this[int index]
+    {
+        get => Pointer[index];
+        set => Pointer[index] = value;
+    }
+
     /// <summary>
     /// The size in bytes of the client-usable memory region of this resource.
     /// </summary>

--- a/PrySec.Core/Memory/MemoryManagement/MemoryManager.cs
+++ b/PrySec.Core/Memory/MemoryManagement/MemoryManager.cs
@@ -51,10 +51,6 @@ public static unsafe partial class MemoryManager
         _freeImpl(ptr);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ZeroMemory<T>(T* ptr, Size_T elementCount) where T : unmanaged =>
-        ZeroMemory((void*)ptr, elementCount * sizeof(T));
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ZeroMemory(void* ptr, Size_T byteSize) =>
         Unsafe.InitBlockUnaligned(ptr, 0x0, byteSize);
 

--- a/PrySec.Security/Cryptography/Csprng/SecureRandom.cs
+++ b/PrySec.Security/Cryptography/Csprng/SecureRandom.cs
@@ -3,7 +3,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
-namespace PrySec.Security.Cryptography.Crng;
+namespace PrySec.Security.Cryptography.Csprng;
 
 public static unsafe class SecureRandom
 {

--- a/PrySec.Security/Cryptography/Encryption/Blake3XofOtp/Implementation/HwIntrinsics/Blake3XofOtpBlockFinalizer.avx2.cs
+++ b/PrySec.Security/Cryptography/Encryption/Blake3XofOtp/Implementation/HwIntrinsics/Blake3XofOtpBlockFinalizer.avx2.cs
@@ -1,5 +1,6 @@
 ﻿using PrySec.Core;
 using PrySec.Core.NativeTypes;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
@@ -9,13 +10,17 @@ internal unsafe class Blake3XofOtpFinalizerHwIntrinsicsAvx2 : IBlake3XofOtpBlock
 {
     private const int VECTOR_SIZE = 32;
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static void FinalizeBlock(void* destination, void* source, Size_T length)
     {
         byte* dst = (byte*)destination;
         byte* src = (byte*)source;
         for (; length >= VECTOR_SIZE; length -= VECTOR_SIZE, src += VECTOR_SIZE, dst += VECTOR_SIZE)
         {
-            Avx.Store(dst, Avx2.Xor(Avx.LoadVector256(src), Avx.LoadVector256(dst)));
+            Vector256<byte> srcVec = Avx.LoadVector256(src);
+            Vector256<byte> dstVec = Avx.LoadVector256(dst);
+            Vector256<byte> result = Avx2.Xor(srcVec, dstVec);
+            Avx.Store(dst, result);
         }
         if (length > 0)
         {

--- a/PrySec.Security/Cryptography/Encryption/Blake3XofOtp/Implementation/HwIntrinsics/Blake3XofOtpBlockFinalizer.avx2.cs
+++ b/PrySec.Security/Cryptography/Encryption/Blake3XofOtp/Implementation/HwIntrinsics/Blake3XofOtpBlockFinalizer.avx2.cs
@@ -15,10 +15,7 @@ internal unsafe class Blake3XofOtpFinalizerHwIntrinsicsAvx2 : IBlake3XofOtpBlock
         byte* src = (byte*)source;
         for (; length >= VECTOR_SIZE; length -= VECTOR_SIZE, src += VECTOR_SIZE, dst += VECTOR_SIZE)
         {
-            Vector256<byte> srcVec = Avx.LoadVector256(src);
-            Vector256<byte> dstVec = Avx.LoadVector256(dst);
-            Vector256<byte> result = Avx2.Xor(srcVec, dstVec);
-            Avx.Store(dst, result);
+            Avx.Store(dst, Avx2.Xor(Avx.LoadVector256(src), Avx.LoadVector256(dst)));
         }
         if (length > 0)
         {

--- a/PrySec.Security/Cryptography/Encryption/Blake3XofOtp/Implementation/HwIntrinsics/Blake3XofOtpBlockFinalizer.sse2.cs
+++ b/PrySec.Security/Cryptography/Encryption/Blake3XofOtp/Implementation/HwIntrinsics/Blake3XofOtpBlockFinalizer.sse2.cs
@@ -14,10 +14,7 @@ internal unsafe class Blake3XofOtpFinalizerHwIntrinsicsSse2 : IBlake3XofOtpBlock
         byte* src = (byte*)source;
         for (; length >= VECTOR_SIZE; length -= VECTOR_SIZE, src += VECTOR_SIZE, dst += VECTOR_SIZE)
         {
-            Vector128<byte> srcVec = Sse2.LoadVector128(src);
-            Vector128<byte> dstVec = Sse2.LoadVector128(dst);
-            Vector128<byte> result = Sse2.Xor(srcVec, dstVec);
-            Sse2.Store(dst, result);
+            Sse2.Store(dst, Sse2.Xor(Sse2.LoadVector128(src), Sse2.LoadVector128(dst)));
         }
         if (length > 0)
         {

--- a/PrySec.Security/Cryptography/Encryption/Blake3XofOtp/Implementation/HwIntrinsics/Blake3XofOtpBlockFinalizer.sse2.cs
+++ b/PrySec.Security/Cryptography/Encryption/Blake3XofOtp/Implementation/HwIntrinsics/Blake3XofOtpBlockFinalizer.sse2.cs
@@ -1,4 +1,5 @@
 ﻿using PrySec.Core.NativeTypes;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
@@ -8,13 +9,17 @@ internal unsafe class Blake3XofOtpFinalizerHwIntrinsicsSse2 : IBlake3XofOtpBlock
 {
     private const int VECTOR_SIZE = 16;
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static void FinalizeBlock(void* destination, void* source, Size_T length)
     {
         byte* dst = (byte*)destination;
         byte* src = (byte*)source;
         for (; length >= VECTOR_SIZE; length -= VECTOR_SIZE, src += VECTOR_SIZE, dst += VECTOR_SIZE)
         {
-            Sse2.Store(dst, Sse2.Xor(Sse2.LoadVector128(src), Sse2.LoadVector128(dst)));
+            Vector128<byte> srcVec = Sse2.LoadVector128(src);
+            Vector128<byte> dstVec = Sse2.LoadVector128(dst);
+            Vector128<byte> result = Sse2.Xor(srcVec, dstVec);
+            Sse2.Store(dst, result);
         }
         if (length > 0)
         {

--- a/PrySec.Security/Cryptography/Hashing/Blake3/Implementation/HwIntrinsics/Blake3.avx2.cs
+++ b/PrySec.Security/Cryptography/Hashing/Blake3/Implementation/HwIntrinsics/Blake3.avx2.cs
@@ -27,7 +27,10 @@ internal unsafe class Blake3HwIntrinsicsAvx2 : IBlake3Implementation
         {
             Hash8Avx2(inputs, blockCount, key, counter, incrementCounter, flags, flagsStart, flagsEnd, output);
             if (incrementCounter)
+            {
                 counter += SimdDegree;
+            }
+
             inputs += SimdDegree;
             inputCount -= SimdDegree;
             output += SimdDegree * BLAKE3_BLOCK_LEN;
@@ -257,7 +260,7 @@ internal unsafe class Blake3HwIntrinsicsAvx2 : IBlake3Implementation
 
         for (int i = 0; i < 8; i++)
         {
-            // TODO: why prefetch the input into all cache levels when were now working with the output?
+            // TODO: why prefetch the input into all cache levels when we're now working with the output?
             Sse.Prefetch0(inputs[i] + blockOffset + 256);
         }
         TransposeVectors(output);

--- a/PrySec.Security/MemoryProtection/Native/Posix/SysMMan/MProtectedMemory__Internal.cs
+++ b/PrySec.Security/MemoryProtection/Native/Posix/SysMMan/MProtectedMemory__Internal.cs
@@ -16,8 +16,6 @@ internal unsafe class MProtectedMemory__Internal<T> : IProtectedMemoryFactory<MP
 {
     private bool disposedValue = false;
 
-    private static readonly ThreadLocal<ProcfsMapsParser> _procfs = new(() => new ProcfsMapsParser(256));
-
     private readonly ISysMManAccessValidator _validator;
 
     private protected MProtectedMemory__Internal(Size_T count)

--- a/PrySec.Security/MemoryProtection/Portable/XofOtp/Blake3XofOtpEncryptedMemory.cs
+++ b/PrySec.Security/MemoryProtection/Portable/XofOtp/Blake3XofOtpEncryptedMemory.cs
@@ -2,7 +2,7 @@
 using PrySec.Core.Memory;
 using PrySec.Core.Memory.MemoryManagement;
 using PrySec.Core.NativeTypes;
-using PrySec.Security.Cryptography.Crng;
+using PrySec.Security.Cryptography.Csprng;
 using System;
 
 namespace PrySec.Security.MemoryProtection.Portable.XofOtp;

--- a/PrySec.Security/MemoryProtection/Portable/XofOtp/Blake3XofOtpEncryptionService.cs
+++ b/PrySec.Security/MemoryProtection/Portable/XofOtp/Blake3XofOtpEncryptionService.cs
@@ -1,6 +1,6 @@
 ﻿using PrySec.Core.Memory;
 using PrySec.Core.Memory.MemoryManagement;
-using PrySec.Security.Cryptography.Crng;
+using PrySec.Security.Cryptography.Csprng;
 using PrySec.Security.Cryptography.Encryption.Blake3XofOtp;
 using PrySec.Security.MemoryProtection.Native.Ntos.MemoryApi;
 using PrySec.Security.MemoryProtection.Portable.ProtectedMemory;

--- a/PrySec.SecurityTests/Cryptography/Encryption/Blake3XofOtp/Blake3XofOtpScpTests.cs
+++ b/PrySec.SecurityTests/Cryptography/Encryption/Blake3XofOtp/Blake3XofOtpScpTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PrySec.Core.Memory.MemoryManagement;
 using PrySec.Core.Memory.MemoryManagement.Implementations.AllocationTracking;
-using PrySec.Security.Cryptography.Crng;
+using PrySec.Security.Cryptography.Csprng;
 using PrySec.Security.Cryptography.Encryption.Blake3XofOtp;
 using PrySec.Security.MemoryProtection.Portable;
 using PrySec.SecurityTests;

--- a/Testing/Program.cs
+++ b/Testing/Program.cs
@@ -31,29 +31,29 @@ using Testing;
 
 unsafe
 {
-    IProtectedMemory<char> memory = Blake3XofOtpEncryptedMemory<char>.Allocate(20);
+    using IProtectedMemory<char> memory = Blake3XofOtpEncryptedMemory<char>.Allocate(20);
     using (IMemoryAccess<char> access = memory.GetAccess())
     {
-        access[4] = 'u';
-        access[17] = 'i';
-        access[3] = 'q';
-        access[18] = 'n';
-        access[6] = 't';
-        access[2] = 'i';
-        access[1] = 'b';
-        access[7] = 'o';
-        access[10] = ' ';
-        access[5] = 'i';
-        access[12] = 'o';
-        access[9] = 's';
-        access[14] = 'p';
-        access[13] = 'm';
         access[0] = 'U';
-        access[19] = 'g';
-        access[11] = 'C';
-        access[16] = 't';
+        access[1] = 'b';
+        access[2] = 'i';
+        access[3] = 'q';
+        access[4] = 'u';
+        access[5] = 'i';
+        access[6] = 't';
+        access[7] = 'o';
         access[8] = 'u';
+        access[9] = 's';
+        access[10] = ' ';
+        access[11] = 'C';
+        access[12] = 'o';
+        access[13] = 'm';
+        access[14] = 'p';
         access[15] = 'u';
+        access[16] = 't';
+        access[17] = 'i';
+        access[18] = 'n';
+        access[19] = 'g';
     }
     Console.WriteLine($"allocation: 0x{(nint)memory.BasePointer:x16}");
     FieldInfo? finfo = typeof(Blake3XofOtpEncryptionService).GetField("_principalKeyMemory", BindingFlags.Static | BindingFlags.NonPublic);

--- a/Testing/Program.cs
+++ b/Testing/Program.cs
@@ -29,55 +29,46 @@ using System.Text;
 using System.Threading;
 using Testing;
 
-try
+unsafe
 {
-    unsafe
+    IProtectedMemory<char> memory = Blake3XofOtpEncryptedMemory<char>.Allocate(20);
+    using (IMemoryAccess<char> access = memory.GetAccess())
     {
-        IProtectedMemory<char> memory = Blake3XofOtpEncryptedMemory<char>.Allocate(20);
-        using (IMemoryAccess<char> access = memory.GetAccess())
-        {
-            access[4] = 'u';
-            access[17] = 'i';
-            access[3] = 'q';
-            access[18] = 'n';
-            access[6] = 't';
-            access[2] = 'i';
-            access[1] = 'b';
-            access[7] = 'o';
-            access[10] = ' ';
-            access[5] = 'i';
-            access[12] = 'o';
-            access[9] = 's';
-            access[14] = 'p';
-            access[13] = 'm';
-            access[0] = 'U';
-            access[19] = 'g';
-            access[11] = 'C';
-            access[16] = 't';
-            access[8] = 'u';
-            access[15] = 'u';
-        }
-        Console.WriteLine($"allocation: 0x{(nint)memory.BasePointer:x16}");
-        FieldInfo? finfo = typeof(Blake3XofOtpEncryptionService).GetField("_principalKeyMemory", BindingFlags.Static | BindingFlags.NonPublic);
-        ProtectedMemory<byte>? masterKey = finfo?.GetValue(null) as ProtectedMemory<byte>;
-        Console.WriteLine($"master key: 0x{(masterKey?.NativeHandle ?? 0):x16}");
-        while (true)
-        {
-            Console.WriteLine("protected!");
-            Console.WriteLine("Press enter to unprotect");
-            Console.ReadLine();
-            using IMemoryAccess<char> _ = memory.GetAccess();
-            Console.WriteLine("unprotected!");
-            Console.WriteLine("Press enter to protect");
-            Console.ReadLine();
-        }
+        access[4] = 'u';
+        access[17] = 'i';
+        access[3] = 'q';
+        access[18] = 'n';
+        access[6] = 't';
+        access[2] = 'i';
+        access[1] = 'b';
+        access[7] = 'o';
+        access[10] = ' ';
+        access[5] = 'i';
+        access[12] = 'o';
+        access[9] = 's';
+        access[14] = 'p';
+        access[13] = 'm';
+        access[0] = 'U';
+        access[19] = 'g';
+        access[11] = 'C';
+        access[16] = 't';
+        access[8] = 'u';
+        access[15] = 'u';
     }
-}
-catch (SecurityException se)
-{
-    Console.WriteLine(se.Message);
-    Console.WriteLine("Memory wiped!");
-    Console.ReadLine();
+    Console.WriteLine($"allocation: 0x{(nint)memory.BasePointer:x16}");
+    FieldInfo? finfo = typeof(Blake3XofOtpEncryptionService).GetField("_principalKeyMemory", BindingFlags.Static | BindingFlags.NonPublic);
+    ProtectedMemory<byte>? masterKey = finfo?.GetValue(null) as ProtectedMemory<byte>;
+    Console.WriteLine($"master key: 0x{(masterKey?.NativeHandle ?? 0):x16}");
+    while (true)
+    {
+        Console.WriteLine("protected!");
+        Console.WriteLine("Press enter to unprotect");
+        Console.ReadLine();
+        using IMemoryAccess<char> _ = memory.GetAccess();
+        Console.WriteLine("unprotected!");
+        Console.WriteLine("Press enter to protect");
+        Console.ReadLine();
+    }
 }
 
 return;

--- a/Testing/Program.cs
+++ b/Testing/Program.cs
@@ -6,23 +6,81 @@ using PrySec.Core.Memory.MemoryManagement;
 using PrySec.Core.Memory.MemoryManagement.Implementations;
 using PrySec.Core.Memory.MemoryManagement.Implementations.AllocationTracking;
 using PrySec.Core.Native.UnixLike.Procfs;
+using PrySec.Core.NativeTypes;
 using PrySec.Core.Primitives.Converters;
 using PrySec.Security.Cryptography.Hashing.Blake2;
+using PrySec.Security.MemoryProtection;
 using PrySec.Security.MemoryProtection.Native.Ntos.DPApi;
 using PrySec.Security.MemoryProtection.Native.Ntos.MemoryApi;
 using PrySec.Security.MemoryProtection.Native.Posix.SysMMan;
 using PrySec.Security.MemoryProtection.Portable;
+using PrySec.Security.MemoryProtection.Portable.ProtectedMemory;
 using PrySec.Security.MemoryProtection.Portable.XofOtp;
 using System;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+using System.Security;
 using System.Text;
 using System.Threading;
 using Testing;
+
+try
+{
+    unsafe
+    {
+        IProtectedMemory<char> memory = Blake3XofOtpEncryptedMemory<char>.Allocate(20);
+        using (IMemoryAccess<char> access = memory.GetAccess())
+        {
+            access[4] = 'u';
+            access[17] = 'i';
+            access[3] = 'q';
+            access[18] = 'n';
+            access[6] = 't';
+            access[2] = 'i';
+            access[1] = 'b';
+            access[7] = 'o';
+            access[10] = ' ';
+            access[5] = 'i';
+            access[12] = 'o';
+            access[9] = 's';
+            access[14] = 'p';
+            access[13] = 'm';
+            access[0] = 'U';
+            access[19] = 'g';
+            access[11] = 'C';
+            access[16] = 't';
+            access[8] = 'u';
+            access[15] = 'u';
+        }
+        Console.WriteLine($"allocation: 0x{(nint)memory.BasePointer:x16}");
+        FieldInfo? finfo = typeof(Blake3XofOtpEncryptionService).GetField("_principalKeyMemory", BindingFlags.Static | BindingFlags.NonPublic);
+        ProtectedMemory<byte>? masterKey = finfo?.GetValue(null) as ProtectedMemory<byte>;
+        Console.WriteLine($"master key: 0x{(masterKey?.NativeHandle ?? 0):x16}");
+        while (true)
+        {
+            Console.WriteLine("protected!");
+            Console.WriteLine("Press enter to unprotect");
+            Console.ReadLine();
+            using IMemoryAccess<char> _ = memory.GetAccess();
+            Console.WriteLine("unprotected!");
+            Console.WriteLine("Press enter to protect");
+            Console.ReadLine();
+        }
+    }
+}
+catch (SecurityException se)
+{
+    Console.WriteLine(se.Message);
+    Console.WriteLine("Memory wiped!");
+    Console.ReadLine();
+}
+
+return;
 
 unsafe
 {

--- a/Testing/Testing.csproj
+++ b/Testing/Testing.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Program.cs~RF12ac1cf.TMP" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.4" />
     <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.13.4" />
   </ItemGroup>


### PR DESCRIPTION
Some of the SIMD code may leak data to the stack when using unoptimized tier 0 JIT compilation. The amount of data depends on the SIMD Vector size. This can be fixed by adding `[MethodImpl(MethodImplOptions.AggressiveOptimization)]` to offending code sections for direct tier 1 jitting.